### PR TITLE
Ensure compatibility with Django 1.10+ MIDDLEWARE

### DIFF
--- a/django_babel/middleware.py
+++ b/django_babel/middleware.py
@@ -4,6 +4,13 @@ from babel import Locale, UnknownLocaleError
 from django.utils.translation import get_language
 from threading import local
 
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # Not required for Django <= 1.9, see:
+    # https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
+    MiddlewareMixin = object
+
 
 __all__ = ['get_current_locale', 'LocaleMiddleware']
 
@@ -19,7 +26,7 @@ def get_current_locale():
     return getattr(_thread_locals, 'locale', None)
 
 
-class LocaleMiddleware(object):
+class LocaleMiddleware(MiddlewareMixin):
 
     """Simple Django middleware that makes available a Babel `Locale` object
     via the `request.locale` attribute.


### PR DESCRIPTION
This PR adds compatibility with Django 1.10+ middlewares to python-babel/django-babel#33.

See: https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware
